### PR TITLE
picochess version

### DIFF
--- a/sources/Makefile
+++ b/sources/Makefile
@@ -4,8 +4,8 @@
 BINDIR = /usr/bin
 
 #define the directory for the data files
-DATADIR = /usr/share/rodentII
-
+# DATADIR = /usr/share/rodentII
+DATADIR = /opt/picochess/engines/rodent2
 
 # define the C compiler to use
 CC = g++

--- a/sources/src/book.cpp
+++ b/sources/src/book.cpp
@@ -356,29 +356,40 @@ U64 sBook::GetPolyglotKey(POS *p)
   return key;
 }
 
-void sBook::OpenPolyglot(void)
+void sBook::OpenPolyglot()
 {
   // check if string contains a line ending information from personality file
   // if found replace with C string termination
   size_t ln = strlen(bookName) - 1;
-  if (*bookName && bookName[ln] == '\n') 
+  if (*bookName && bookName[ln] == '\n')
     bookName[ln] = '\0';
-  bookFile = fopen(bookName, "rb");
+
+  char nameBook[255];
+
+  strcpy(nameBook, "");
+  strcpy(nameBook, bookPath);
+
+  strcat(nameBook, bookName); // append bookname
+  bookFile = fopen(nameBook, "rb");
 
   if (bookFile != NULL) {
-
     if (fseek(bookFile, 0, SEEK_END) == -1) {
       bookFile = NULL;
       return;
     }
 
-    bookSize = ftell(bookFile) / 16;
+    bookSize = (int) ftell(bookFile) / 16;
     if (bookSize == -1) {
       bookFile = NULL;
       return;
     }
   }
 }
+
+void sBook::setPath(char *path)
+{
+  bookPath = path;
+};
 
 int my_random(int n)
 {
@@ -404,7 +415,7 @@ int sBook::GetPolyglotMove(POS *p, int printOutput)
   nOfChoices = 0;
 
   if (bookFile != NULL && bookSize != 0) {
-    srand(Timer.GetMS());
+    srand((unsigned int) Timer.GetMS());
 
     for (pos = FindPos(key); pos < bookSize; pos++) {
 

--- a/sources/src/book.h
+++ b/sources/src/book.h
@@ -33,7 +33,7 @@ struct polyglot_move {
     int  learn;
 };
 
-#include<stdio.h>
+#include <stdio.h>
 
 struct sBook {
 private:
@@ -41,19 +41,19 @@ private:
     FILE * bookFile;
     int moves[100];
     int nOfChoices;
-    char testString [12];
     int IsInfrequent(int val, int maxFreq);
-    void ParseBookEntry(char * ptr, int line_no);
     int FindPos(U64 key);
     void ReadEntry(polyglot_move * entry, int n);
     U64 ReadInteger(int size);
 public:
     char *bookName;
+    char *bookPath;
     int GetPolyglotMove(POS *p, int printOutput);
     U64 GetPolyglotKey(POS *p);
     void OpenPolyglot(void);
     void ClosePolyglot(void);
     void Init(POS *p);
+    void setPath(char *path);
 };
 
 extern sBook GuideBook;

--- a/sources/src/main.cpp
+++ b/sources/src/main.cpp
@@ -85,44 +85,51 @@ int main() {
   Param.Default();
   Param.DynamicInit();
   InitSearch();
+
 #ifdef _WIN32 || _WIN64
   // if we are on Windows search for books and settings in same directory as rodentII.exe
+  MainBook.setPath('');
+  GuideBook.setPath('');
   MainBook.bookName = "books/rodent.bin";
   GuideBook.bookName = "books/guide.bin";
   ReadPersonality("basic.ini");
+
 #elif __linux || __unix
   // if we are on Linux
   // first check, if compiler got told where books and settings are stored
 #ifdef BOOKPATH
-  char path[255]; // space for complete path and filename
-  char nameMainbook[20] = "/rodent.bin";
-  char nameGuidebook[20]= "/guide.bin";
-  char namePersonality[20]= "/basic.ini";
+  char nameMainbook[255];
+  char nameGuidebook[255];
+  char namePersonality[255];
+
+  strcpy(nameMainbook, ""); // first clear
+  strcpy(nameMainbook, STR(BOOKPATH)); // copy path from c preprocessor here
+  strcat(nameMainbook, "/");
+  MainBook.setPath(nameMainbook);
+
+  strcpy(nameGuidebook, ""); // first clear
+  strcpy(nameGuidebook, STR(BOOKPATH)); // copy path from c preprocessor here
+  strcat(nameGuidebook, "/");
+  GuideBook.setPath(nameGuidebook);
+
   // process Mainbook
-  strcpy(path, ""); // first clear
-  strcpy(path, STR(BOOKPATH)); // copy path from c preprocessor here
-  strcat(path, nameMainbook); // append bookname
-  MainBook.bookName = path; // store it
+  MainBook.bookName = "books/rodent.bin"; // store it
   // process Guidebook
-  strcpy(path, "");
-  strcpy(path, STR(BOOKPATH));
-  strcat(path, nameGuidebook);
-  GuideBook.bookName = nameGuidebook;
+  GuideBook.bookName = "books/guide.bin"; // store it
+
   // process Personality file
-  strcpy(path, "");
-  strcpy(path, STR(BOOKPATH));
-  strcat(path, namePersonality);
-  ReadPersonality(path);
-#else // if no path was given than we assume that files are stored at /usr/share/rodentII
-  MainBook.bookName = "/usr/share/rodentII/rodent.bin";
-  GuideBook.bookName = "/usr/share/rodentII/guide.bin";
-  ReadPersonality("/usr/share/rodentII/basic.ini");
+  strcpy(namePersonality, "");
+  strcpy(namePersonality, STR(BOOKPATH));
+  strcat(namePersonality, "/basic.ini");
+  ReadPersonality(namePersonality);
 #endif
 
 #else
   // a platform we have not tested yet. We assume that opening books and 
   // settings are stored within the same directory. Similiar to Windows.
   printf("Platform unknown. We assume that opening books and settings are stored within RodentII path");
+  MainBook.setPath('');
+  GuideBook.setPath('');
   MainBook.bookName = "books/rodent.bin";
   GuideBook.bookName = "books/guide.bin";
   ReadPersonality("basic.ini");


### PR DESCRIPTION
On Linux environment the DATADIR isn't set as root dir for many data files.
That is happening at startup and also during uci (parameter) read.
Fixes #37

BTW. i didnt fix the "install" Makefile-path...Also i think, these data files shouldnt be copied to one dir, instead keep the folder structure.